### PR TITLE
feat: add php 8.0 docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   - PHPVERSION="7.1"
   - PHPVERSION="7.2"
   - PHPVERSION="7.4"
+  - PHPVERSION="8.0"
 
 script:
   - docker build -f ./${PHPVERSION}/Dockerfile -t ${PHPVERSION} ./${PHPVERSION}

--- a/8.0/Dockerfile
+++ b/8.0/Dockerfile
@@ -1,0 +1,44 @@
+FROM php:8.0-fpm-alpine
+
+ENV WORKDIR "/var/www/app"
+
+RUN apk upgrade --update && apk --no-cache add \
+    gcc g++ make autoconf tzdata openntpd libcurl curl-dev coreutils \
+    freetype-dev libxpm-dev libjpeg-turbo-dev libvpx-dev \
+    libpng-dev libressl libressl-dev libxml2-dev icu-dev libzip-dev postgresql-dev yarn
+
+RUN apk add --no-cache --virtual build-dependencies icu-dev libxml2-dev freetype-dev libpng-dev libjpeg-turbo-dev g++ make autoconf
+
+RUN docker-php-ext-configure intl \
+    && docker-php-ext-configure opcache \
+    && docker-php-ext-configure gd --with-freetype --with-jpeg
+
+RUN docker-php-ext-install -j$(nproc) gd pdo pdo_mysql pdo_pgsql bcmath zip intl opcache
+
+# Install Redis
+RUN docker-php-source extract \
+    && pecl install redis \
+    && docker-php-ext-enable redis \
+    && docker-php-source delete
+
+# Add timezone
+RUN ln -s /usr/share/zoneinfo/UTC /etc/localtime && \
+    "date"
+
+# Install composer
+RUN curl -sS https://getcomposer.org/installer | \
+    php -- --install-dir=/usr/local/bin --filename=composer
+
+# Cleanup
+RUN rm -rf /var/cache/apk/* \
+    && find / -type f -iname \*.apk-new -delete \
+    && rm -rf /var/cache/apk/*
+
+RUN mkdir -p ${WORKDIR}
+RUN chown www-data:www-data -R ${WORKDIR}
+
+WORKDIR ${WORKDIR}
+
+EXPOSE 9000
+
+CMD ["php-fpm"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ A PHP Docker image based on the official PHP Alpine image, and includes addition
 Please note that the image contains also [Composer](https://getcomposer.org/)
 
 ## Tags
-* 7, 7.2, latest [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/7.2/Dockerfile)
+* 8.0 [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/8.0/Dockerfile)
+* 7.4 [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/7.4/Dockerfile)
+* 7.2 [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/7.2/Dockerfile)
 * 7.1 [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/7.1/Dockerfile)
 * 7.0 [(Dockerfile)](https://github.com/kariae/symfony-php/blob/master/7.0/Dockerfile)
 


### PR DESCRIPTION
Hello @kariae ,

I’ve removed this extension iconv, curl, json cause they’re enabled by default in PHP 8.0:
` docker run php:8.0-fpm-alpine php -m | grep iconv` 
`docker run php:8.0-fpm-alpine php -m | grep curl` 
`docker run php:8.0-fpm-alpine php -m | grep json` 

I’ve also removed xmlrpc because is [removed](https://php.watch/versions/8.0/xmlrpc) in PHP 8.0 and moved to PECL

Best regards.